### PR TITLE
feat: add intro and installation sections in uAgents docs

### DIFF
--- a/pages/concepts/_meta.json
+++ b/pages/concepts/_meta.json
@@ -1,3 +1,6 @@
 {
-  "agents" : "Agents"
+  "agents" : "μAgents",
+  "index" : "Index",
+  "ledger" : "Ledger",
+  "search" : "Search"
 }

--- a/pages/concepts/agents/_meta.json
+++ b/pages/concepts/agents/_meta.json
@@ -1,0 +1,6 @@
+{
+  "agents" : "Introduction \uD83D\uDE80",
+  "rationale" : "Why μAgents \uD83E\uDD14\uD83D\uDCA1",
+  "interoperability" : "Interoperability \uD83D\uDCBB"
+}
+

--- a/pages/concepts/agents/agents.md
+++ b/pages/concepts/agents/agents.md
@@ -1,7 +1,5 @@
 # μAgents
 
-## Introduction
+## Introduction 🚀
 
 The μAgents (micro-Agents) project is a lightweight framework designed to facilitate the development of decentralized agents. μAgents are autonomous entities which interact, negotiate, and collaborate with other agents in a decentralized environment. μAgents provides developers with the tools and resources to create intelligent and self-governing systems that can efficiently operate across different fields and industries.
-
-

--- a/pages/concepts/agents/interoperability.md
+++ b/pages/concepts/agents/interoperability.md
@@ -1,0 +1,1 @@
+# Interoperability 💻

--- a/pages/concepts/agents/rationale.md
+++ b/pages/concepts/agents/rationale.md
@@ -1,15 +1,21 @@
-## rework this to be a reasons why we developed this, not why you should. Show our passion for this, why we think this is world changing.
+# Why μAgents 🤔💡
 
-## Why μAgents
+In the evolving landscape of decentralized technology, the emergence of autonomous agents has revolutionized the approach we have to problem-solving, decision-making, and collaborative behaviors. Intelligent agents hold immense potential to transform industries and enhance the understanding of complex systems. 
 
-Here are a few of the reasons to build with μAgents:
+Fetch.ai introduces the μAgents Framework designed to empower developers with the tools to build intelligent, autonomous agents that interact, collaborate, and navigate the complexity of the modern world.
 
-1. **Easiness to learn**: μAgents offers a user-friendly learning curve, allowing developers to quickly grasp the concepts and get started with building intelligent and autonomous μAgents. Follow our guides to install the [Python](https://pypi.org/project/uagents/) package and create your first μAgent in just a few minutes.
+At the core of this revolutionary technology lies the concept of μAgents, a type of decentralized, autonomous entities that transcend traditional boundaries, unlocking a realm of possibilities yet unexplored. As pioneers, we are strongly driven by our passion for innovation and the potential of μAgents to reshape the structure of our society.
 
-2. **Customizability**: With μAgents, you have the freedom to unleash your creativity and build any type of agent you can imagine. The framework provides extensive customization options, empowering you to tailor the behavior, decision-making processes, and interactions of your μAgents according to your specific use case.
+μAgents offer a gateway to a future where intelligent entities communicate, negotiate, and collaborate in a straightforward and trustless fashion, harnessing the power of decentralized networks. The days of centralized decision-making have come to an end. Now, autonomous agents have the chance of taking charge, empowered by the framework to manifest unique, customizable behaviors that suit the most specific use cases. The journey begins with a few lines of code, where creativity meets functionality, and the potential to build intelligent agents that adapt, learn, and engage with the world becomes a tangible reality.
 
-3. **Connectedness**: When an μAgent starts up, it becomes part of the rapidly expanding network of μAgents. By registering on the Almanac, which is the smart contract developed and deployed on the Fetch.ai blockchain, your μAgents instantaneously joins this dynamic ecosystem of agents, enabling effortless collaboration and interaction with other participants.
+Here are a _few of the reasons_ to build with μAgents:
 
-4. **Security**: Security is a top priority in decentralized environments, and the framework ensures the protection of your μAgent's messages and wallets. Through cryptographic measures, the identities and assets associated with μAgents are safeguarded, providing peace of mind and maintaining the integrity of your μAgent's interactions and transactions.
+- **Easiness to learn**: μAgents offers a user-friendly learning curve, allowing developers to quickly grasp the concepts and get started with building intelligent and autonomous μAgents. Follow our guides to install the [Python](https://pypi.org/project/uagents/) package and create your first μAgent in just a few minutes.
 
-5. **Platform and language independency**: While initially launched as a Python library, the exchange protocol used by μAgents is defined in terms of standard data types. This inherent flexibility allows the framework to transcend any specific platform or programming language. As a lightweight and adaptable framework, expect the emergence of packages and implementations in other programming languages to further expand the reach and accessibility of μAgents in the near future.
+- **Customizability**: with μAgents, you have the freedom to unleash your creativity and build any type of agent you can imagine. The framework provides extensive customization options, empowering you to tailor the behavior, decision-making processes, and interactions of your μAgents according to your specific use case.
+
+- **Connectedness**: when an μAgent starts up, it becomes part of the rapidly expanding network of μAgents. By registering on the Almanac [↗️](/references/contracts/uagents-almanac/almanac-overview.md)️, which is the smart contract developed and deployed on the Fetch.ai blockchain, your μAgents instantaneously joins this dynamic ecosystem of agents, enabling effortless collaboration and interaction with other participants.
+
+- **Security**: security is a top priority in decentralized environments, and the framework ensures the protection of your μAgent's messages and wallets. Through cryptographic measures, the identities and assets associated with μAgents are safeguarded, providing peace of mind and maintaining the integrity of your μAgent's interactions and transactions.
+
+- **Platform and language independency**: while initially launched as a Python library, the exchange protocol [↗️](/references/uagents/uagents-protocols/exchange-protocol.md)️ used by μAgents is defined in terms of standard data types. This inherent flexibility allows the framework to transcend any specific platform or programming language. As a lightweight and adaptable framework, expect the emergence of packages and implementations in other programming languages to further expand the reach and accessibility of μAgents in the near future.

--- a/pages/guides/agents/_meta.json
+++ b/pages/guides/agents/_meta.json
@@ -1,5 +1,5 @@
 {
-  "installing-uagent" : "Installation",
+  "installing-uagent" : "Installation \uD83D\uDEE0️\uD83D\uDCF2",
   "create-a-uagent" : "Creating your first μAgent",
   "create-uagent-name-address" : "Printing name and address",
   "getting-uagent-address" : "Getting a μAgent address",
@@ -7,8 +7,6 @@
   "storage-function" : "Using μAgents storage function",
   "register-in-almanac" : "Registering in the Almanac Contract",
   "communicating-with-other-agents" : "Communicating with other μAgents \uD83D\uDCF1\uD83E\uDD16️",
-  "remote-communication" : "μAgents remote communication",
-  "agentverse-mailbox" : "How to use the AgentVerse Mailbox Service",
   "booking-demo" : "How to book a table at a restaurant using uAgents",
   "message-verification" : "How to use uAgents to verify messages",
   "send-tokens" : "How to use uAgents to send tokens",

--- a/pages/guides/agents/installing-uagent.md
+++ b/pages/guides/agents/installing-uagent.md
@@ -1,4 +1,4 @@
-# Installation
+# Installation 🛠️📲
 
 ## System Requirements
 
@@ -10,7 +10,6 @@ On your computer, you may need to install:
 - [PIP](https://pypi.org/project/pip/) (Python Installs Packages).
 - [Poetry](https://python-poetry.org/) for virtual environments (optional).
 - μAgents framework.
-
 
 ## Install with Pip
 
@@ -42,8 +41,7 @@ On your computer, you may need to install:
     ```py
     poetry shell
     ```
-
-
+   
 ## Troubleshooting
 
 It is possible that you may face issues during the installation process. Here, you can find common problems and their solutions:

--- a/pages/references/uagents/index.md
+++ b/pages/references/uagents/index.md
@@ -1,43 +1,35 @@
-# μAgents Framework documentation index
+# μAgents Framework Documentation Index
 
 **Introduction**:
 
-- [Introduction](/docs/concepts/agents/uagents-intro.md)
-- [Why μAgents](/docs/concepts/agents/why-uagents.md)
-- [Interoperability](/docs/concepts/agents/interoperability.md)
-
-**Installation**:
-
-- [System Requirements](/docs/guides/agents/installation/system-requirements.md)
-- [Install with Pip](/docs/guides/agents/installation/install-with-pip.md)
-- [Install from source code](/docs/guides/agents/installation/install-from-source-code.md)
-- [Troubleshooting](/docs/guides/agents/installation/troubleshooting.md)
+- [Introduction 🚀](/concepts/agents/agents.md)
+- [Why μAgents 🤔💡](/concepts/agents/rationale.md)
+- [Interoperability 💻](/concepts/agents/interoperability.md)
 
 **Guides**:
 
-- [Creating your first μAgent](/docs/guides/agents/create-a-uagent.md)
-- [Printing name and address](/docs/guides/agents/create-uagent-name-address.md)
-- [Getting a μAgent address](/docs/guides/agents/getting-uagent-address.md)
-- [μAgents Interval Task](/docs/guides/agents/interval-task.md)
-- [μAgents Storage Functions](/docs/guides/agents/storage-function.md)
-- [Registering in the Almanac contract](/docs/guides/agents/register-in-almanac.md)
-- [Start communicating with other agents](/docs/guides/agents/start-communicating-with-other-agents):
-  - [Local communication](/docs/guides/agents/start-communicating-with-other-agents/local-communication.md)
-  - [Remote communication](/docs/guides/agents/start-communicating-with-other-agents/remote-communication.md)
-- [How to use the AgentVerse Mailbox Service](/docs/guides/agents/agentverse-mailbox.md)
-- [How to book a table at a restaurant using μAgents](/docs/guides/agents/booking-demo.md)
-- [How to use μAgents to verify messages](/docs/guides/agents/message-verification.md)
-- [How to use μAgents to send tokens](/docs/guides/agents/send-tokens.md)
-- [How to use the μAgents to simulate a cleaning scenario](/docs/guides/agents/cleaning-demo.md)
+- [Installation 🛠️📲](/guides/agents/installing-uagent.md)
+- [Creating your first μAgent](/guides/agents/create-a-uagent.md)
+- [Printing name and address](/guides/agents/create-uagent-name-address.md)
+- [Getting a μAgent address](/guides/agents/getting-uagent-address.md)
+- [μAgents Interval Task](/guides/agents/interval-task.md)
+- [μAgents Storage Functions](/guides/agents/storage-function.md)
+- [Registering in the Almanac contract](/guides/agents/register-in-almanac.md)
+- [Communicating with other μAgents 📱🤖](/guides/agents/communicating-with-other-agents.md)
+- [How to book a table at a restaurant using μAgents](/guides/agents/booking-demo.md)
+- [How to use μAgents to verify messages](/guides/agents/message-verification.md)
+- [How to use μAgents to send tokens](/guides/agents/send-tokens.md)
+- [How to use the μAgents to simulate a cleaning scenario](/guides/agents/cleaning-demo.md)
+- [Creating a μAgent to generate revenue on your data](/guides/agents/creating-an-agent-to-generate-revenue-on-your-data.md)
 
 **Almanac Contract and Remote Communication**:
 
-- [Almanac contract overview](/docs/references/contracts/uagents-almanac/almanac-overview.md)
-- [Endpoint weighting and registration in the Almanac contract](/docs/references/contracts/uagents-almanac/endpoints.md)
-- [The Agentverse Mailbox Service](/docs/references/contracts/uagents-almanac/register-in-the-agentverse-mailbox.md)
+- [Almanac contract overview](/references/contracts/uagents-almanac/almanac-overview.md)
+- [Endpoint weighting and registration in the Almanac contract](/references/contracts/uagents-almanac/endpoints.md)
+- [The Agentverse Mailbox Service](/references/contracts/uagents-almanac/register-in-the-agentverse-mailbox.md)
 
 **Protocols**:
 
-- [μAgents Protocols](/docs/references/uagents/uagents-protocols/agent-protocols.md)
-- [Exchange Protocol](/docs/references/uagents/uagents-protocols/exchange-protocol.md)
-- [Storage](/docs/references/uagents/uagents-protocols/storage.md)
+- [μAgents Protocols](/references/uagents/uagents-protocols/agent-protocols.md)
+- [Exchange Protocol](/references/uagents/uagents-protocols/exchange-protocol.md)
+- [Storage](/references/uagents/uagents-protocols/storage.md)


### PR DESCRIPTION
This adds intro and installation sections. I have closed the previous PR for this as it contained also changes to other sections whereas this one focuses only on these two 
