### PR TITLE
feat(misc): refactor fauna and add refresh mechanism

### DIFF
--- a/pages/api/api-requests.ts
+++ b/pages/api/api-requests.ts
@@ -1,0 +1,101 @@
+/* eslint-disable no-useless-catch */
+import axios from "axios";
+import { getCookie, setCookie, deleteCookie } from "cookies-next";
+import { NextApiRequest, NextApiResponse } from "next";
+
+class CustomError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+async function getNewAccessToken(refreshToken: string) {
+  try {
+    const response = await fetch(`https://accounts.fetch.ai/v1/tokens`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+      }),
+    });
+    const data = await response.json();
+    if (response.ok && response.status === 200) {
+      return data.access_token;
+    }
+    if (response.status === 422) {
+      throw new CustomError("Refresh token expired", 422);
+    }
+  } catch (refreshError) {
+    throw new CustomError(refreshError.message, 422);
+  }
+}
+
+async function retryRequest(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  accessToken: string,
+  url: string,
+) {
+  try {
+    const response = await axios({
+      method: req.method,
+      url: url,
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: req.body,
+    });
+    return res.status(response.status).json({ data: response.data });
+  } catch (error) {
+    return res
+      .status(error.response.status)
+      .json({ error: error.response.data });
+  }
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { url } = req.query;
+  const accessToken = getCookie("fauna", { req, res });
+  const refreshToken = getCookie("refresh_token", { req, res });
+
+  try {
+    const response = await axios({
+      method: req.method,
+      url: url as string,
+      headers: { Authorization: `Bearer ${accessToken}` },
+      data: req.body,
+    });
+    deleteCookie("fauna", { req, res });
+    return res.status(response.status).json({ data: response.data });
+  } catch (error) {
+    if (error.response.status === 401) {
+      try {
+        const newAccessToken = await getNewAccessToken(refreshToken);
+        if (newAccessToken) {
+          setCookie("fauna", newAccessToken, { req, res });
+          return await retryRequest(req, res, newAccessToken, url as string);
+        } else {
+          return res
+            .status(422)
+            .json({ message: "unable to got new access token" });
+        }
+      } catch (Error) {
+        if (Error.status === 422) {
+          return res.status(Error.status).json({ message: Error });
+        }
+        return res.status(500).json({ message: Error });
+      }
+    } else {
+      return res
+        .status(error.response.status)
+        .json({ error: error.response.data });
+    }
+  }
+}

--- a/src/core/fauna.tsx
+++ b/src/core/fauna.tsx
@@ -1,4 +1,7 @@
-export async function getTokenFromAuthCode(authCode: string): Promise<string> {
+export async function getTokenFromAuthCode(authCode: string): Promise<{
+  access_token: string;
+  refresh_token: string;
+}> {
   const r = await fetch(`https://accounts.fetch.ai/v1/tokens`, {
     method: "POST",
     headers: {
@@ -15,8 +18,11 @@ export async function getTokenFromAuthCode(authCode: string): Promise<string> {
     throw new Error("Failed to get token");
   }
 
-  const { access_token } = await r.json();
-  return access_token;
+  const { access_token, refresh_token } = await r.json();
+  return {
+    access_token: access_token,
+    refresh_token: refresh_token,
+  };
 }
 
 export async function getNewAccessToken(currentToken: string) {

--- a/src/lib/fetch-json.ts
+++ b/src/lib/fetch-json.ts
@@ -25,10 +25,24 @@ export class FetchError extends Error {
   }
 }
 
-export default async function fetchJson<JSON = unknown>(
+export default async function fetchJson<Response>(
   input: RequestInfo,
   init?: RequestInit,
-): Promise<JSON> {
+): Promise<Response> {
+  if (
+    init &&
+    init.method &&
+    !init.method.includes("GET") &&
+    init.body &&
+    init.body
+  ) {
+    init.body = JSON.stringify(init.body);
+    if (!init.headers) {
+      init.headers = {};
+    }
+    init.headers["Content-Type"] = "application/json";
+  }
+
   const response = await fetch(input, init);
   const data = await response.json();
   if (response.ok) {


### PR DESCRIPTION
migrate all our Agentverse and AI engine APIs to the server-side. Upon user login, we'll store the access_token and refresh_token in server cookies. Then, whenever our Agentverse and AI engine APIs return a 401 status code, we'll trigger the refresh_token API to obtain a new token. And when the refresh token expires, we'll clear the session, automatically logging out the user.