### PR TITLE
fix(docs): change metadata to metadata_properties in functions API doc

### DIFF
--- a/pages/apis/ai-engine/functions.mdx
+++ b/pages/apis/ai-engine/functions.mdx
@@ -115,38 +115,38 @@ properties={[
       required: false,
     },
     {
-      name: "metadata",
+      name: "metadata_properties",
       type: "JSON",
       description:
         'Optional JSON object. Gives user the option to add additional metadata related to the function. Currently only geo-location data is supported. Structure is {"geo_location":{"location":{"lat":${lat},"lon":${lon}},"radius":${radius}}} - see details below.',
       required: false,
     },
     {
-      name: "metadata-geo_location",
+      name: "metadata_properties-geo_location",
       type: "JSON",
       description:
         'JSON object. Currently this is the only metadata supported. Structure is {"location":{"lat":${lat},"lon":${lon}},"radius":${radius}} - see details below.',
     },
     {
-      name: "metadata-geo_location-location",
+      name: "metadata_properties-geo_location-location",
       type: "JSON",
       description:
         'JSON object. Latitude and longitude data relate. Structure is {"lat":${lat},"lon":${lon}} - see details below.',
     },
     {
-      name: "metadata-geo_location-location-lat",
+      name: "metadata_properties-geo_location-location-lat",
       type: "float",
       description:
         'Latitude related to the function.',
     },
     {
-      name: "metadata-geo_location-location-lon",
+      name: "metadata_properties-geo_location-location-lon",
       type: "float",
       description:
         'Longitude related to the function.',
     },
     {
-      name: "metadata-geo_location-radius",
+      name: "metadata_properties-geo_location-radius",
       type: "float",
       description:
         'Optional radius related to the function.',
@@ -162,7 +162,7 @@ properties={[
     "modelName": "StockPrice/StocksProtocol",
     "arguments": [{"name": "symbol", "required": true, "type": "string", "description": "The symbol of the share, for example: AAPL, GOOG, MSFT, etc."}],
     "type": "PRIMARY",
-    "metadata": {
+    "metadata_properties": {
       "geo_location": {
         "location": {
           "lat": 52.205338,
@@ -322,7 +322,8 @@ properties={[
         "createdAt": "2023-10-22T21:28:46",
         "updatedAt": "2023-10-22T21:28:46",
         "status": "CREATED",
-        "isDialogue": false
+        "isDialogue": false,
+        "metadata": null
     }
   }
   pathParameters={{function_id:"your_function_id",}}
@@ -388,38 +389,38 @@ properties={[
       required: false,
     },
     {
-      name: "metadata",
+      name: "metadata_properties",
       type: "JSON",
       description:
         'Optional JSON object. Gives user the option to add additional metadata related to the function. Currently only geo-location data is supported. Structure is {"geo_location":{"location":{"lat":${lat},"lon":${lon}},"radius":${radius}}} - see details below.',
       required: false,
     },
     {
-      name: "metadata-geo_location",
+      name: "metadata_properties-geo_location",
       type: "JSON",
       description:
         'JSON object. Currently this is the only metadata supported. Structure is {"location":{"lat":${lat},"lon":${lon}},"radius":${radius}} - see details below.',
     },
     {
-      name: "metadata-geo_location-location",
+      name: "metadata_properties-geo_location-location",
       type: "JSON",
       description:
         'JSON object. Latitude and longitude data relate. Structure is {"lat":${lat},"lon":${lon}} - see details below.',
     },
     {
-      name: "metadata-geo_location-location-lat",
+      name: "metadata_properties-geo_location-location-lat",
       type: "float",
       description:
         'Latitude related to the function.',
     },
     {
-      name: "metadata-geo_location-location-lon",
+      name: "metadata_properties-geo_location-location-lon",
       type: "float",
       description:
         'Longitude related to the function.',
     },
     {
-      name: "metadata-geo_location-radius",
+      name: "metadata_properties-geo_location-radius",
       type: "float",
       description:
         'Optional radius related to the function.',
@@ -443,7 +444,7 @@ properties={[
             }
         ],
         "type": "PRIMARY",
-        "metadata": {
+        "metadata_properties": {
           "geo_location": {
             "location": {
               "lat": 52.205338,
@@ -517,7 +518,9 @@ properties={[
         "type": "PRIMARY",
         "createdAt": "2023-10-22T21:28:46",
         "updatedAt": "2023-10-22T21:28:46",
-        "status": "CREATED"
+        "status": "CREATED",
+        "isDialogue": false,
+        "metadata": null
     }
   }
   pathParameters={{function_id:"your_function_id",}}
@@ -565,7 +568,9 @@ properties={[
         "type": "PRIMARY",
         "createdAt": "2023-10-22T21:28:46",
         "updatedAt": "2023-10-22T21:28:46",
-        "status": "TESTING"
+        "status": "TESTING",
+        "isDialogue": false,
+        "metadata": null
     }
   }
   pathParameters={{function_id:"your_function_id",}}
@@ -600,7 +605,9 @@ properties={[
         "type": "PRIMARY",
         "createdAt": "2023-10-22T21:28:46",
         "updatedAt": "2023-10-22T21:28:46",
-        "status": "IN-REVIEW"
+        "status": "IN-REVIEW",
+        "isDialogue": false,
+        "metadata": null
     }
   }
   pathParameters={{function_id:"your_function_id",}}
@@ -634,7 +641,9 @@ properties={[
         "type": "PRIMARY",
         "createdAt": "2023-10-22T21:28:46",
         "updatedAt": "2023-10-22T21:28:46",
-        "status": "TESTING"
+        "status": "TESTING",
+        "isDialogue": false,
+        "metadata": null
     }
   }
   pathParameters={{function_id:"your_function_id",}}


### PR DESCRIPTION
## Proposed Changes

Currently, the functions API doc erroneously use `"metadata"` in the requests. This wouldn't work, we need to use `"metadata_properties"` instead. This PR changes these occurrences. Additionally, the `"isDialogue"` and the `"metadata"` fields were missing in a few response examples, so this PR adds these as well.

## Linked Issues

This was the source of issue https://github.com/fetchai/agentverse/issues/54

## Types of changes

- [ ] Content update.
- [x] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/docs/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

## Further comments
