### PR TITLE
fix(docs): Rename method to match example

### DIFF
--- a/pages/guides/agents/quickstart.mdx
+++ b/pages/guides/agents/quickstart.mdx
@@ -129,7 +129,7 @@ Open `simple_example.py` in your text editor and add the following code:
 
     # Define behavior for handling messages received by Emma
     @emma.on_message(model=Message)
-    async def sigmar_message_handler(ctx: Context, sender: str, msg: Message):
+    async def emma_message_handler(ctx: Context, sender: str, msg: Message):
         ctx.logger.info(f"Received message from {sender}: {msg.message}")
 
     # Define behavior for handling messages received by Liam


### PR DESCRIPTION
## Proposed Changes

The sigmar_message_handler method is used for Emma's on_message handling. To be consistent, sigmar_message_handler should be renamed to emma_message_handler. Sigmar belongs to a different guide found at pages/guides/agents/intermediate/communicating-with-other-agents.mdx

## Types of changes

- [x] Content update.
- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/docs/blob/main/CONTRIBUTING.md) guide
- [ ] Checks and tests pass locally
