### PR TITLE
feat: update version for main network

### DIFF
--- a/pages/references/ledger/active-networks.mdx
+++ b/pages/references/ledger/active-networks.mdx
@@ -17,6 +17,7 @@ Below you can find all of needed specifications for the **Fetch Main Network (Ma
     |                | [v0.10.5 ↗️](https://github.com/fetchai/fetchd/releases/tag/v0.10.5) for blocks >  7305500, standard software upgrade |
     |                | [v0.10.7 ↗️](https://github.com/fetchai/fetchd/releases/tag/v0.10.7) for blocks > 11235678, standard software upgrade |
     |                | [v0.11.3 ↗️](https://github.com/fetchai/fetchd/releases/tag/v0.11.3) for blocks > 14699873, standard software upgrade |
+    |                | [v0.14.0 ↗️](https://github.com/fetchai/fetchd/releases/tag/v0.14.0) for blocks > 18938999, standard software upgrade |
     | RPC Endpoint   | [https://rpc-fetchhub.fetch.ai:443 ↗️](https://rpc-fetchhub.fetch.ai:443) |
     | GRPC Endpoint  | [https://grpc-fetchhub.fetch.ai:443 ↗️](https://grpc-fetchhub.fetch.ai:443) |
     | REST Endpoint  | [https://rest-fetchhub.fetch.ai:443 ↗️](https://rest-fetchhub.fetch.ai:443) |


### PR DESCRIPTION
## Proposed Changes

In the list of active networks, the v0.14.0 upgrade is not listed which is kind of misleading. This PR adds the version and upgrade's block height.

## Linked Issues

NA

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Content update.
- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/docs/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

## Further comments

NA
