### PR TITLE
docs: fix minor grammatical issues in docs

### DIFF
--- a/pages/guides/fetchai-sdk/quickstart.mdx
+++ b/pages/guides/fetchai-sdk/quickstart.mdx
@@ -157,7 +157,7 @@ if __name__ == "__main__":
 
 There's a lot to unpack there, but as this is a quickstart, let's just cover the essentials:
 
-An Agent is identifiable by its [seed ↗️](../agents/getting-started/seedphrase); we use this to load in an Agent often with `Identity.from_seed("some str as your seed", 0)`
+An Agent is identifiable by their [seed ↗️](../agents/getting-started/seedphrase); we use this to load in an Agent often with `Identity.from_seed("some str as your seed", 0)`
 
 Registration allows other Agents to find you, you can see this in `register_with_agentverse`. We specify a `readme` which is an xml string so that LLMs can read this content in a more structured manner. Very useful for search in more complex demos.
 

--- a/pages/guides/fetchai-sdk/quickstart.mdx
+++ b/pages/guides/fetchai-sdk/quickstart.mdx
@@ -4,7 +4,7 @@ The Fetch.ai SDK gives you easy access to the core components of the uAgents lib
 
 Allowing you to create Agents outside the asynchronous library of uAgents. This is really great if you want to build synchronous programs but still have agentic functionalities.
 
-Let's build two simple [Agent ↗️](/guides/agents/getting-started/whats-an-agent) system using Flask, and OpenAI.
+Let's build two simple [Agent ↗️](/guides/agents/getting-started/whats-an-agent) systems using Flask, and OpenAI.
 
 ## Installation
 
@@ -157,9 +157,9 @@ if __name__ == "__main__":
 
 There's a lot to unpack there, but as this is a quickstart, let's just cover the essentials:
 
-An Agent is identifiable by their [seed ↗️](../agents/getting-started/seedphrase); we use this to load in an Agent often with `Identity.from_seed("some str as your seed", 0)`
+An Agent is identifiable by its [seed ↗️](../agents/getting-started/seedphrase); we use this to load in an Agent often with `Identity.from_seed("some str as your seed", 0)`
 
-Registration allows other Agents to find you, you can see this in `register_with_agentverse`. We specify a `readme` which is a xml string so that LLMs can read this content in a more structured manner. Very useful for search in more complex demos.
+Registration allows other Agents to find you, you can see this in `register_with_agentverse`. We specify a `readme` which is an xml string so that LLMs can read this content in a more structured manner. Very useful for search in more complex demos.
 
 `/webhook` is where our Agent accepts an incoming message. They will receive this message when another Agents search for it and match. Within this Agent, we get the data with `data = request.json` and then we get some of the message objects, our Agent expects the payload to have `date of birth` and `gender` as keys.
 


### PR DESCRIPTION
## Proposed Changes

I noticed a few grammar mistakes in the documentation and fixed them to improve clarity:  

- Corrected agreement in "two simple … system" → "two simple … systems"  
- Fixed pronoun inconsistency: "their" → "its" for singular "Agent"  
- Adjusted article usage: "a xml" → "an XML"  

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [x] Content update.
- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [x] I have read the [CONTRIBUTING](https://github.com/fetchai/docs/blob/main/CONTRIBUTING.md) guide
- [x] Checks and tests pass locally

