### PR TITLE
chore(misc): migrate workflows from PAT to GitHub App auth

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -46,10 +46,18 @@ jobs:
           NEWSLETTER_BASE_URL: ${{ secrets.NEWSLETTER_BASE_URL }}
           SENDER_TOKEN: ${{ secrets.SENDER_TOKEN }}
 
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.FETCHAI_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.FETCHAI_DISPATCH_APP_KEY }}
+          repositories: infra-production-deployment
+
       - name: Trigger Image Update
         run: |
           curl -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Authorization: token ${{ secrets.ORG_DISPATCH_RENDER_TOKEN }}" \
+          -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
           --request POST \
           --data '{"event_type": "docs-build", "client_payload": {"image": "${{ env.IMAGE }}", "image_path": "${{ env.IMAGE_PATH }}", "key_path": "${{ env.KEY_PATH }}", "tag": "${{ env.TAG }}", "commit_message_service": "${{ env.SERVICE_NAME }}"}}' \
           ${{ env.TARGET_REPO }}

--- a/.github/workflows/deploy-staging-revamp.yml
+++ b/.github/workflows/deploy-staging-revamp.yml
@@ -46,10 +46,18 @@ jobs:
           NEWSLETTER_BASE_URL: ${{ secrets.NEWSLETTER_BASE_URL }}
           SENDER_TOKEN: ${{ secrets.SENDER_TOKEN }}
 
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.FETCHAI_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.FETCHAI_DISPATCH_APP_KEY }}
+          repositories: infra-sandbox-london-b-deployment
+
       - name: Repository Dispatch
         run: |
           curl -f -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Authorization: token ${{ secrets.ORG_DISPATCH_RENDER_TOKEN }}" \
+          -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
           --request POST \
           --data '{"event_type": "docs-revamp-staging-build", "client_payload": {"image": "'"${{ secrets.IMAGE_REVAMP_REPOSITORY }}"'" , "image_path": "values", "key_path": ".image.tag", "commit_message_service": "Docs Revamp Staging", "tag": "'"${{ steps.lookup.outputs.version }}"'"}}' \
           https://api.github.com/repos/fetchai/infra-sandbox-london-b-deployment/dispatches

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -61,4 +61,3 @@ jobs:
           --request POST \
           --data '{"event_type": "docs-staging-build", "client_payload": {"image": "'"${{ secrets.STAGING_IMAGE_REPOSITORY }}"'" , "image_path": "values", "key_path": ".website.image.tag", "commit_message_service": "Docs Staging", "tag": "'"${{ steps.lookup.outputs.version }}"'"}}' \
           https://api.github.com/repos/fetchai/infra-sandbox-london-b-deployment/dispatches
-

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,10 +46,19 @@ jobs:
           NEWSLETTER_BASE_URL: ${{ secrets.NEWSLETTER_BASE_URL }}
           SENDER_TOKEN: ${{ secrets.SENDER_TOKEN }}
 
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.FETCHAI_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.FETCHAI_DISPATCH_APP_KEY }}
+          repositories: infra-sandbox-london-b-deployment
+
       - name: Repository Dispatch
         run: |
           curl -f -H "Accept: application/vnd.github.everest-preview+json" \
-          -H "Authorization: token ${{ secrets.ORG_DISPATCH_RENDER_TOKEN }}" \
+          -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
           --request POST \
           --data '{"event_type": "docs-staging-build", "client_payload": {"image": "'"${{ secrets.STAGING_IMAGE_REPOSITORY }}"'" , "image_path": "values", "key_path": ".website.image.tag", "commit_message_service": "Docs Staging", "tag": "'"${{ steps.lookup.outputs.version }}"'"}}' \
           https://api.github.com/repos/fetchai/infra-sandbox-london-b-deployment/dispatches
+


### PR DESCRIPTION
Migrates `.github/workflows/deploy-staging.yml` and `.github/workflows/deploy-production.yml` from `ORG_DISPATCH_RENDER_TOKEN` PAT to `fetchai-dispatch` GitHub App auth (Wave 2 of Phase 1 plan).

Adds `actions/create-github-app-token@v1` scoped to `infra-production-deployment` before the Repository Dispatch step in each workflow. No other changes.